### PR TITLE
Store element offsets, for Node::child_at_offset

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,6 @@ ptr-union = "1.2"
 rc-borrow = "1.1" # public
 slice-dst = "1.3" # public
 text-size = "0.99" # public
+
+# Hashbrown is used directly only for access to std's unstable hash_raw_entry.
+# If/when hash_raw_entry is stabilized, this dependency should be removed.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,9 @@ text-size = "0.99" # public
 # If/when hash_raw_entry is stabilized, this dependency should be removed.
 
 [dev-dependencies]
+criterion = "0.3"
 insta = "0.15"
+
+[[bench]]
+name = "node_children"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,6 @@ text-size = "0.99" # public
 
 # Hashbrown is used directly only for access to std's unstable hash_raw_entry.
 # If/when hash_raw_entry is stabilized, this dependency should be removed.
+
+[dev-dependencies]
+insta = "0.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,9 @@ authors = [
 ]
 
 [dependencies]
-erasable = "1.1"
+erasable = "1.1" # public
 hashbrown = "0.7"
 ptr-union = "1.2"
-rc-borrow = "1.1"
-slice-dst = "1.3"
-text-size = "0.99"
+rc-borrow = "1.1" # public
+slice-dst = "1.3" # public
+text-size = "0.99" # public

--- a/benches/node_children.rs
+++ b/benches/node_children.rs
@@ -1,7 +1,6 @@
-use sorbus::NodeOrToken;
 use {
     criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput},
-    sorbus::{green, ArcBorrow, Kind},
+    sorbus::{green, ArcBorrow, Kind, NodeOrToken},
     std::sync::Arc,
 };
 

--- a/benches/node_children.rs
+++ b/benches/node_children.rs
@@ -1,0 +1,83 @@
+use sorbus::NodeOrToken;
+use {
+    criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput},
+    sorbus::{green, ArcBorrow, Kind},
+    std::sync::Arc,
+};
+
+fn black_hole<T>(t: T) {
+    black_box(t);
+}
+
+/// Make a green tree containing some number of `(+ (* 15 2) 62)` nodes.
+fn make_tree(scale: usize) -> Arc<green::Node> {
+    const WS: Kind = Kind(0);
+    const L_PAREN: Kind = Kind(1);
+    const R_PAREN: Kind = Kind(2);
+    const ATOM: Kind = Kind(3);
+    const LIST: Kind = Kind(4);
+
+    let mut builder = green::TreeBuilder::new();
+    #[rustfmt::skip]
+    let tree = builder
+        .start_node(LIST)
+            .token(L_PAREN, "(")
+            .token(ATOM, "+")
+            .token(WS, " ")
+            .start_node(LIST)
+                .token(L_PAREN, "(")
+                .token(ATOM, "*")
+                .token(WS, " ")
+                .token(ATOM, "15")
+                .token(WS, " ")
+                .token(ATOM, "2")
+                .token(R_PAREN, ")")
+            .finish_node()
+            .token(WS, " ")
+            .token(ATOM, "62")
+            .token(R_PAREN, ")")
+        .finish_node()
+        .finish();
+
+    builder.start_node(LIST);
+    for _ in 0..scale {
+        builder.add(tree.clone());
+    }
+    builder.finish_node().finish()
+}
+
+fn flat_children_iterate(c: &mut Criterion) {
+    const SCALE: usize = 256;
+    let mut group = c.benchmark_group("flat_children");
+    for &scale in [SCALE, 2 * SCALE, 4 * SCALE, 8 * SCALE, 16 * SCALE].iter() {
+        group.throughput(Throughput::Elements(scale as u64));
+        let tree = make_tree(scale);
+        group.bench_with_input(BenchmarkId::from_parameter(scale), &tree, |b, tree| {
+            b.iter(|| tree.children().for_each(black_hole));
+        });
+    }
+    group.finish();
+}
+
+fn visit(el: NodeOrToken<ArcBorrow<'_, green::Node>, ArcBorrow<'_, green::Token>>) {
+    match el {
+        NodeOrToken::Node(node) => node.children().for_each(visit),
+        NodeOrToken::Token(token) => black_hole(token),
+    }
+}
+
+fn visit_children_iterate(c: &mut Criterion) {
+    const SCALE: usize = 256;
+    let mut group = c.benchmark_group("visit_children");
+    for &scale in [SCALE, 2 * SCALE, 4 * SCALE, 8 * SCALE, 16 * SCALE].iter() {
+        group.throughput(Throughput::Elements(scale as u64));
+        let tree = make_tree(scale);
+        group.bench_with_input(BenchmarkId::from_parameter(scale), &tree, |b, tree| {
+            b.iter(|| tree.children().for_each(visit));
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, flat_children_iterate, visit_children_iterate);
+criterion_main!(benches);

--- a/src/green/builder.rs
+++ b/src/green/builder.rs
@@ -70,6 +70,11 @@ pub struct Builder {
 }
 
 impl Builder {
+    /// Create a new builder.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
     /// Create a new node or clone a new Arc to an existing equivalent one.
     ///
     /// This checks children for identity equivalence, not structural,

--- a/src/green/builder.rs
+++ b/src/green/builder.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        green::{Element, Node, Token},
+        green::{Node, Token},
         Kind, NodeOrToken,
     },
     hashbrown::{hash_map::RawEntryMut, HashMap, HashSet},

--- a/src/green/builder.rs
+++ b/src/green/builder.rs
@@ -75,13 +75,13 @@ impl Builder {
     /// This checks children for identity equivalence, not structural,
     /// so it is `O(children.len())` and only caches higher-level nodes
     /// if the lower-level nodes have also been cached.
-    pub fn node<I, E>(&mut self, kind: Kind, children: I) -> Arc<Node>
+    pub fn node<I>(&mut self, kind: Kind, children: I) -> Arc<Node>
     where
-        E: Into<NodeOrToken<Arc<Node>, Arc<Token>>>,
-        I: IntoIterator<Item = E>,
+        I: IntoIterator,
+        I::Item: Into<NodeOrToken<Arc<Node>, Arc<Token>>>,
         I::IntoIter: ExactSizeIterator,
     {
-        let node = Node::new(kind, children.into_iter().map(Into::into).map(Into::into));
+        let node = Node::new(kind, children.into_iter().map(Into::into));
         self.nodes.get_or_insert(node).0.clone()
     }
 
@@ -119,7 +119,7 @@ pub struct Checkpoint(usize);
 pub struct TreeBuilder {
     cache: Builder,
     stack: Vec<(Kind, usize)>,
-    children: Vec<Element>,
+    children: Vec<NodeOrToken<Arc<Node>, Arc<Token>>>,
 }
 
 impl TreeBuilder {
@@ -140,7 +140,7 @@ impl TreeBuilder {
 
     /// Add an element to the current branch.
     pub fn add(&mut self, element: impl Into<NodeOrToken<Arc<Node>, Arc<Token>>>) -> &mut Self {
-        self.children.push(element.into().into());
+        self.children.push(element.into());
         self
     }
 
@@ -151,10 +151,10 @@ impl TreeBuilder {
     }
 
     /// Add a new node to the current branch.
-    pub fn node<I, E>(&mut self, kind: Kind, children: I) -> &mut Self
+    pub fn node<I>(&mut self, kind: Kind, children: I) -> &mut Self
     where
-        E: Into<NodeOrToken<Arc<Node>, Arc<Token>>>,
-        I: IntoIterator<Item = E>,
+        I: IntoIterator,
+        I::Item: Into<NodeOrToken<Arc<Node>, Arc<Token>>>,
         I::IntoIter: ExactSizeIterator,
     {
         let node = self.cache.node(kind, children);

--- a/src/green/element.rs
+++ b/src/green/element.rs
@@ -24,9 +24,9 @@ use {
         ArcBorrow, NodeOrToken, TextSize,
     },
     erasable::{ErasablePtr, ErasedPtr},
-    ptr_union::{Union2, UnionBuilder},
+    ptr_union::{Union2, UnionBuilder, Enum2},
     std::{
-        fmt,
+        fmt::{self, Debug},
         hash::{self, Hash},
         ptr,
         sync::Arc,
@@ -213,9 +213,13 @@ impl Drop for HalfAlignedElement {
     }
 }
 
-impl fmt::Debug for Element {
+impl Debug for Element {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("{Element}")
+        write!(f, "(offset {:?}) ", &self.offset())?;
+        match self.ptr().unpack() {
+            Enum2::A(node) => Debug::fmt(&node, f),
+            Enum2::B(token) => Debug::fmt(&token, f),
+        }
     }
 }
 

--- a/src/green/element.rs
+++ b/src/green/element.rs
@@ -220,3 +220,21 @@ impl<'a> From<&'a Element> for NodeOrToken<ArcBorrow<'a, Node>, ArcBorrow<'a, To
             .unwrap()
     }
 }
+
+impl<'a> From<&'a FullAlignedElement> for NodeOrToken<ArcBorrow<'a, Node>, ArcBorrow<'a, Token>> {
+    fn from(this: &'a FullAlignedElement) -> Self {
+        let this = this.ptr();
+        None.or_else(|| this.with_a(|&node| NodeOrToken::Node(node)))
+            .or_else(|| this.with_b(|&token| NodeOrToken::Token(token)))
+            .unwrap()
+    }
+}
+
+impl<'a> From<&'a HalfAlignedElement> for NodeOrToken<ArcBorrow<'a, Node>, ArcBorrow<'a, Token>> {
+    fn from(this: &'a HalfAlignedElement) -> Self {
+        let this = this.ptr();
+        None.or_else(|| this.with_a(|&node| NodeOrToken::Node(node)))
+            .or_else(|| this.with_b(|&token| NodeOrToken::Token(token)))
+            .unwrap()
+    }
+}

--- a/src/green/element.rs
+++ b/src/green/element.rs
@@ -8,75 +8,83 @@ use {
     text_size::TextLen,
 };
 
-// SAFETY: align of Node and Token are >= 2
-const ARC_UNION_PROOF: UnionBuilder<Union2<Arc<Node>, Arc<Token>>> =
-    unsafe { UnionBuilder::new2() };
-const REF_UNION_PROOF: UnionBuilder<Union2<&Node, &Token>> = unsafe { UnionBuilder::new2() };
+// // SAFETY: align of Node and Token are >= 2
+// const ARC_UNION_PROOF: UnionBuilder<Union2<Arc<Node>, Arc<Token>>> =
+//     unsafe { UnionBuilder::new2() };
+// const REF_UNION_PROOF: UnionBuilder<Union2<&Node, &Token>> = unsafe { UnionBuilder::new2() };
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub(super) struct Element {
-    raw: Union2<Arc<Node>, Arc<Token>>, // NB: Union2 does automatic thinning
+    // raw: Union2<Arc<Node>, Arc<Token>>, // NB: Union2 does automatic thinning
 }
 
 impl Element {
     pub(super) fn node(node: Arc<Node>) -> Element {
-        Element { raw: ARC_UNION_PROOF.a(node) }
+        todo!()
+        // Element { raw: ARC_UNION_PROOF.a(node) }
     }
 
     pub(super) fn into_node(self) -> Option<Arc<Node>> {
-        self.raw.into_a().ok()
+        todo!()
+        // self.raw.into_a().ok()
     }
 
     pub(super) fn token(token: Arc<Token>) -> Element {
-        Element { raw: ARC_UNION_PROOF.b(token) }
+        todo!()
+        // Element { raw: ARC_UNION_PROOF.b(token) }
     }
 
     pub(super) fn len(&self) -> TextSize {
-        match self.raw.as_deref(REF_UNION_PROOF).unpack() {
-            Enum2::A(node) => node.len(),
-            Enum2::B(token) => token.len(),
-        }
+        todo!()
+        // match self.raw.as_deref(REF_UNION_PROOF).unpack() {
+        //     Enum2::A(node) => node.len(),
+        //     Enum2::B(token) => token.len(),
+        // }
     }
 }
 
 impl TextLen for &'_ Element {
     fn text_len(self) -> TextSize {
-        self.len()
+        todo!()
+        // self.len()
     }
 }
 
 impl From<&'_ Element> for NodeOrToken<ArcBorrow<'_, Node>, ArcBorrow<'_, Token>> {
     fn from(this: &'_ Element) -> Self {
-        // SAFETY: borrow lifetime is tied to heap lifetime we manage
-        unsafe {
-            None.or_else(|| this.raw.with_a(|node| NodeOrToken::Node(erase_lt(node).into())))
-                .or_else(|| this.raw.with_b(|token| NodeOrToken::Token(erase_lt(token).into())))
-                .unwrap()
-        }
+        todo!()
+        // // SAFETY: borrow lifetime is tied to heap lifetime we manage
+        // unsafe {
+        //     None.or_else(|| this.raw.with_a(|node| NodeOrToken::Node(erase_lt(node).into())))
+        //         .or_else(|| this.raw.with_b(|token| NodeOrToken::Token(erase_lt(token).into())))
+        //         .unwrap()
+        // }
     }
 }
 
 impl From<Element> for NodeOrToken<Arc<Node>, Arc<Token>> {
     fn from(this: Element) -> Self {
-        Err(this.raw)
-            .or_else(|this| this.into_a().map(NodeOrToken::Node))
-            .or_else(|this| this.into_b().map(NodeOrToken::Token))
-            .unwrap()
+        todo!()
+        // Err(this.raw)
+        //     .or_else(|this| this.into_a().map(NodeOrToken::Node))
+        //     .or_else(|this| this.into_b().map(NodeOrToken::Token))
+        //     .unwrap()
     }
 }
 
 impl From<NodeOrToken<Arc<Node>, Arc<Token>>> for Element {
     fn from(value: NodeOrToken<Arc<Node>, Arc<Token>>) -> Self {
-        match value {
-            NodeOrToken::Node(node) => Self::node(node),
-            NodeOrToken::Token(token) => Self::token(token),
-        }
+        todo!()
+        // match value {
+        //     NodeOrToken::Node(node) => Self::node(node),
+        //     NodeOrToken::Token(token) => Self::token(token),
+        // }
     }
 }
 
-/// # Safety
-///
-/// References must not be misused per the Rust memory model.
-unsafe fn erase_lt<'input, 'output, T>(r: &'input T) -> &'output T {
-    mem::transmute(r)
-}
+// /// # Safety
+// ///
+// /// References must not be misused per the Rust memory model.
+// unsafe fn erase_lt<'input, 'output, T>(r: &'input T) -> &'output T {
+//     mem::transmute(r)
+// }

--- a/src/green/element.rs
+++ b/src/green/element.rs
@@ -24,15 +24,13 @@ use {
         ArcBorrow, NodeOrToken, TextSize,
     },
     erasable::{ErasablePtr, ErasedPtr},
-    ptr_union::{Enum2, Union2, UnionBuilder},
+    ptr_union::{Union2, UnionBuilder},
     std::{
         fmt,
-        ptr,
         hash::{self, Hash},
-        mem::{self, ManuallyDrop},
+        ptr,
         sync::Arc,
     },
-    text_size::TextLen,
 };
 
 // SAFETY: align of Node and Token are >= 2
@@ -65,10 +63,6 @@ struct FullAlignedElementRepr {
 /// # Safety
 ///
 /// Must be aligned to 8 bytes (usize).
-///
-/// An improperly aligned element may only exist as long as is required to
-/// write it to an aligned location; no methods may be used until the element
-/// has been properly aligned.
 #[repr(transparent)]
 pub(super) struct FullAlignedElement {
     repr: FullAlignedElementRepr,
@@ -92,10 +86,6 @@ struct HalfAlignedElementRepr {
 ///
 /// Must be aligned to 8 bytes + 4 (usize + 1/2).
 /// (That is, aligned to 4 but not 8.)
-///
-/// An improperly aligned element may only exist as long as is required to
-/// write it to an aligned location; no methods may be used until the element
-/// has been properly aligned.
 #[repr(transparent)]
 pub(super) struct HalfAlignedElement {
     repr: HalfAlignedElementRepr,

--- a/src/green/mod.rs
+++ b/src/green/mod.rs
@@ -11,4 +11,4 @@ pub use self::{
     node::{Children, Node},
     token::Token,
 };
-pub(self) use element::Element;
+pub(self) use element::{Element, FullAlignedElement, HalfAlignedElement};

--- a/src/green/node.rs
+++ b/src/green/node.rs
@@ -42,6 +42,21 @@ impl hash::Hash for Node {
     }
 }
 
+// Element is a union, so we have to make sure to drop them manually here.
+impl Drop for Node {
+    fn drop(&mut self) {
+        let mut children = self.children.iter_mut();
+        unsafe {
+            (|| -> Option<()> {
+                loop {
+                    ptr::drop_in_place(children.next()?.full_aligned_mut());
+                    ptr::drop_in_place(children.next()?.half_aligned_mut());
+                }
+            })();
+        }
+    }
+}
+
 #[allow(clippy::len_without_is_empty)]
 impl Node {
     /// The kind of this node.

--- a/src/green/node.rs
+++ b/src/green/node.rs
@@ -1,15 +1,13 @@
 use {
     crate::{
-        green::{Element, Token},
+        green::{Element, FullAlignedElement, HalfAlignedElement, Token},
         ArcBorrow, Kind, NodeOrToken, TextSize,
     },
     erasable::{Erasable, ErasedPtr},
     slice_dst::{AllocSliceDst, SliceDst},
-    std::{alloc::Layout, hash, iter::FusedIterator, mem, ptr, slice, sync::Arc},
+    std::{alloc::Layout, hash, iter::FusedIterator, mem::ManuallyDrop, ptr, slice, sync::Arc},
     text_size::TextLen,
 };
-use std::mem::ManuallyDrop;
-use crate::green::element::{FullAlignedElement, HalfAlignedElement};
 
 /// A nonleaf node in the immutable green tree.
 ///

--- a/src/green/node.rs
+++ b/src/green/node.rs
@@ -107,6 +107,7 @@ impl Node {
         let (layout, offset_1) = layout.extend(Layout::new::<Kind>()).unwrap();
         let (layout, offset_2) = layout.extend(Layout::new::<TextSize>()).unwrap();
         let (layout, offset_3) = layout.extend(Layout::array::<Element>(len).unwrap()).unwrap();
+        let layout = layout.align_to(8).unwrap();
         (layout.pad_to_align(), [offset_0, offset_1, offset_2, offset_3])
     }
 

--- a/src/green/node.rs
+++ b/src/green/node.rs
@@ -55,7 +55,8 @@ impl Node {
 
     /// Child elements of this node.
     pub fn children(&self) -> Children<'_> {
-        Children { inner: self.children.iter() }
+        todo!()
+        // Children { inner: self.children.iter() }
     }
 }
 
@@ -91,55 +92,56 @@ impl Node {
         let (layout, [children_len_offset, kind_offset, text_len_offset, children_offset]) =
             Self::layout(len);
 
-        unsafe {
-            // SAFETY: closure fully initializes the place
-            A::new_slice_dst(len, |ptr| {
-                /// Helper to drop children on panic.
-                struct ChildrenWriter {
-                    raw: *mut Element,
-                    len: usize,
-                }
-
-                impl Drop for ChildrenWriter {
-                    fn drop(&mut self) {
-                        unsafe {
-                            ptr::drop_in_place(ptr::slice_from_raw_parts_mut(self.raw, self.len));
-                        }
-                    }
-                }
-
-                impl ChildrenWriter {
-                    unsafe fn push(&mut self, element: Element) {
-                        ptr::write(self.raw.add(self.len), element);
-                        self.len += 1;
-                    }
-
-                    fn finish(self) {
-                        mem::forget(self)
-                    }
-                }
-
-                let raw = ptr.as_ptr().cast::<u8>();
-
-                ptr::write(raw.add(children_len_offset).cast(), children_len);
-                ptr::write(raw.add(kind_offset).cast(), kind);
-
-                let mut children_writer =
-                    ChildrenWriter { raw: raw.add(children_offset).cast(), len: 0 };
-                for _ in 0..len {
-                    let child: Element =
-                        children.next().expect("children iterator over-reported length");
-                    text_len = text_len.checked_add(child.len()).expect("TextSize overflow");
-                    children_writer.push(child);
-                }
-                assert!(children.next().is_none(), "children iterator under-reported length");
-
-                ptr::write(raw.add(text_len_offset).cast(), text_len);
-                debug_assert_eq!(layout, Layout::for_value(ptr.as_ref()));
-
-                children_writer.finish()
-            })
-        }
+        todo!()
+        // unsafe {
+        //     // SAFETY: closure fully initializes the place
+        //     A::new_slice_dst(len, |ptr| {
+        //         /// Helper to drop children on panic.
+        //         struct ChildrenWriter {
+        //             raw: *mut Element,
+        //             len: usize,
+        //         }
+        //
+        //         impl Drop for ChildrenWriter {
+        //             fn drop(&mut self) {
+        //                 unsafe {
+        //                     ptr::drop_in_place(ptr::slice_from_raw_parts_mut(self.raw, self.len));
+        //                 }
+        //             }
+        //         }
+        //
+        //         impl ChildrenWriter {
+        //             unsafe fn push(&mut self, element: Element) {
+        //                 ptr::write(self.raw.add(self.len), element);
+        //                 self.len += 1;
+        //             }
+        //
+        //             fn finish(self) {
+        //                 mem::forget(self)
+        //             }
+        //         }
+        //
+        //         let raw = ptr.as_ptr().cast::<u8>();
+        //
+        //         ptr::write(raw.add(children_len_offset).cast(), children_len);
+        //         ptr::write(raw.add(kind_offset).cast(), kind);
+        //
+        //         let mut children_writer =
+        //             ChildrenWriter { raw: raw.add(children_offset).cast(), len: 0 };
+        //         for _ in 0..len {
+        //             let child: Element =
+        //                 children.next().expect("children iterator over-reported length");
+        //             text_len = text_len.checked_add(child.len()).expect("TextSize overflow");
+        //             children_writer.push(child);
+        //         }
+        //         assert!(children.next().is_none(), "children iterator under-reported length");
+        //
+        //         ptr::write(raw.add(text_len_offset).cast(), text_len);
+        //         debug_assert_eq!(layout, Layout::for_value(ptr.as_ref()));
+        //
+        //         children_writer.finish()
+        //     })
+        // }
     }
 }
 
@@ -177,7 +179,8 @@ pub struct Children<'a> {
 impl<'a> Children<'a> {
     /// Get the next item in the iterator without advancing it.
     pub fn peek(&self) -> Option<NodeOrToken<ArcBorrow<'a, Node>, ArcBorrow<'a, Token>>> {
-        self.inner.as_slice().first().map(Into::into)
+        todo!()
+        // self.inner.as_slice().first().map(Into::into)
     }
 
     /// Get the nth item in the iterator without advancing it.
@@ -185,7 +188,8 @@ impl<'a> Children<'a> {
         &self,
         n: usize,
     ) -> Option<NodeOrToken<ArcBorrow<'a, Node>, ArcBorrow<'a, Token>>> {
-        self.inner.as_slice().get(n).map(Into::into)
+        todo!()
+        // self.inner.as_slice().get(n).map(Into::into)
     }
 
     /// Divide this iterator into two at an index.
@@ -197,8 +201,9 @@ impl<'a> Children<'a> {
     ///
     /// Panics if `mid > len`.
     pub fn split_at(&self, mid: usize) -> (Self, Self) {
-        let (left, right) = self.inner.as_slice().split_at(mid);
-        (Children { inner: left.iter() }, Children { inner: right.iter() })
+        todo!()
+        // let (left, right) = self.inner.as_slice().split_at(mid);
+        // (Children { inner: left.iter() }, Children { inner: right.iter() })
     }
 }
 
@@ -212,40 +217,48 @@ impl<'a> Iterator for Children<'a> {
     type Item = NodeOrToken<ArcBorrow<'a, Node>, ArcBorrow<'a, Token>>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.inner.next().map(Into::into)
+        todo!()
+        // self.inner.next().map(Into::into)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        self.inner.size_hint()
+        todo!()
+        // self.inner.size_hint()
     }
 
     fn count(self) -> usize {
-        self.inner.count()
+        todo!()
+        // self.inner.count()
     }
 
     fn last(self) -> Option<Self::Item> {
-        self.inner.last().map(Into::into)
+        todo!()
+        // self.inner.last().map(Into::into)
     }
 
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        self.inner.nth(n).map(Into::into)
+        todo!()
+        // self.inner.nth(n).map(Into::into)
     }
 }
 
 impl ExactSizeIterator for Children<'_> {
     #[inline(always)]
     fn len(&self) -> usize {
-        self.inner.len()
+        todo!()
+        // self.inner.len()
     }
 }
 
 impl DoubleEndedIterator for Children<'_> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.inner.next_back().map(Into::into)
+        todo!()
+        // self.inner.next_back().map(Into::into)
     }
 
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
-        self.inner.nth_back(n).map(Into::into)
+        todo!()
+        // self.inner.nth_back(n).map(Into::into)
     }
 }
 

--- a/src/green/node.rs
+++ b/src/green/node.rs
@@ -5,7 +5,7 @@ use {
     },
     erasable::{Erasable, ErasedPtr},
     slice_dst::{AllocSliceDst, SliceDst},
-    std::{alloc::Layout, hash, iter::FusedIterator, mem, ptr, slice},
+    std::{alloc::Layout, hash, iter::FusedIterator, mem, ptr, slice, sync::Arc},
     text_size::TextLen,
 };
 
@@ -81,7 +81,7 @@ impl Node {
     pub(super) fn new<A, I>(kind: Kind, children: I) -> A
     where
         A: AllocSliceDst<Self>,
-        I: IntoIterator<Item = Element>,
+        I: IntoIterator<Item = NodeOrToken<Arc<Node>, Arc<Token>>>,
         I::IntoIter: ExactSizeIterator,
     {
         let mut children = children.into_iter();

--- a/src/green/token.rs
+++ b/src/green/token.rs
@@ -3,6 +3,7 @@ use {
     erasable::{Erasable, ErasedPtr},
     slice_dst::{AllocSliceDst, SliceDst},
     std::{alloc::Layout, convert::TryFrom, hash, ptr},
+    text_size::TextLen,
 };
 
 /// A leaf token in the immutable green tree.
@@ -103,5 +104,11 @@ unsafe impl SliceDst for Token {
     #[allow(clippy::cast_ptr_alignment)]
     fn retype(ptr: ptr::NonNull<[()]>) -> ptr::NonNull<Self> {
         ptr::NonNull::new(ptr.as_ptr() as *mut _).unwrap()
+    }
+}
+
+impl TextLen for &'_ Token {
+    fn text_len(self) -> TextSize {
+        self.len()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,11 +10,11 @@
 #![feature(alloc_layout_extra)] // rust-lang/rust#69362, hopefully targeting 1.44
 #![forbid(unconditional_recursion)]
 #![warn(missing_debug_implementations, missing_docs)]
-#![allow(unused)]
 
 #[cfg(not(any(target_pointer_width = "32", target_pointer_width = "64")))]
 compile_error!("sorbus only works when sizeof(*const ()) is u32 or u64");
 
+#[allow(unused)]
 const ASSERT_TEXTSIZE_IS_U32: fn() = || {
     let _ = std::mem::transmute::<u32, text_size::TextSize>;
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,13 @@
 #![warn(missing_debug_implementations, missing_docs)]
 #![allow(unused)]
 
+#[cfg(not(any(target_pointer_width = "32", target_pointer_width = "64")))]
+compile_error!("sorbus only works when sizeof(*const ()) is u32 or u64");
+
+const ASSERT_TEXTSIZE_IS_U32: fn() = || {
+    let _ = std::mem::transmute::<u32, text_size::TextSize>;
+};
+
 pub mod green;
 mod utils;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@
 #![feature(alloc_layout_extra)] // rust-lang/rust#69362, hopefully targeting 1.44
 #![forbid(unconditional_recursion)]
 #![warn(missing_debug_implementations, missing_docs)]
+#![allow(unused)]
 
 pub mod green;
 mod utils;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,6 @@
 use {
     crate::prelude::{GreenNode, GreenToken},
     std::{ops::Deref, sync::Arc},
-    erasable::ErasablePtr,
 };
 
 /// Raw kind tag for each element in the tree.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,12 +1,23 @@
 use {
     crate::prelude::{GreenNode, GreenToken},
-    std::{ops::Deref, sync::Arc},
+    std::{
+        fmt::{self, Debug},
+        ops::Deref,
+        sync::Arc,
+    },
 };
 
 /// Raw kind tag for each element in the tree.
 #[repr(transparent)]
-#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
+#[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub struct Kind(pub u16);
+
+/// Skip multiline, just do it inline
+impl Debug for Kind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Kind({})", self.0)
+    }
+}
 
 /// Enum wrapping either a node or a token.
 #[allow(missing_docs)]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,7 @@
 use {
     crate::prelude::{GreenNode, GreenToken},
     std::{ops::Deref, sync::Arc},
+    erasable::ErasablePtr,
 };
 
 /// Raw kind tag for each element in the tree.

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -1,0 +1,43 @@
+//! These tests don't necessarily assert anything. Instead,
+//! they exist primarily to exercise the API under Miri as a sanitizer.
+
+use sorbus::*;
+
+#[test]
+/// This test creates a tree for the sexpr
+///
+/// ```lisp
+/// (+ (* 15 2) 62)
+/// ```
+fn make_sexpr_tree() {
+    const WS: Kind = Kind(0);
+    const L_PAREN: Kind = Kind(1);
+    const R_PAREN: Kind = Kind(2);
+    const ATOM: Kind = Kind(3);
+    const LIST: Kind = Kind(4);
+
+    #[rustfmt::skip]
+    let tree = green::TreeBuilder::new()
+        .start_node(LIST)
+            .token(L_PAREN, "(")
+            .token(ATOM, "+")
+            .token(WS, " ")
+            .start_node(LIST)
+                .token(L_PAREN, "(")
+                .token(ATOM, "*")
+                .token(WS, " ")
+                .token(ATOM, "15")
+                .token(WS, " ")
+                .token(ATOM, "2")
+                .token(R_PAREN, ")")
+            .finish_node()
+            .token(WS, " ")
+            .token(ATOM, "62")
+            .token(R_PAREN, ")")
+        .finish_node()
+        .finish();
+
+    tree.child_at_offset(5.into());
+    tree.children().for_each(drop);
+    dbg!(tree);
+}

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -39,5 +39,10 @@ fn make_sexpr_tree() {
 
     tree.child_at_offset(5.into());
     tree.children().for_each(drop);
-    dbg!(tree);
+
+    if cfg!(miri) {
+        dbg!(tree);
+    } else {
+        insta::assert_debug_snapshot!(tree);
+    }
 }

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -1,14 +1,19 @@
 //! These tests don't necessarily assert anything. Instead,
 //! they exist primarily to exercise the API under Miri as a sanitizer.
 
-use sorbus::*;
+use {
+    sorbus::{green, Kind, NodeOrToken},
+    std::{ptr, sync::Arc},
+};
 
-#[test]
 /// This test creates a tree for the sexpr
 ///
 /// ```lisp
 /// (+ (* 15 2) 62)
 /// ```
+///
+/// This test shows an example of using the top-down `TreeBuilder`.
+#[test]
 fn make_sexpr_tree() {
     const WS: Kind = Kind(0);
     const L_PAREN: Kind = Kind(1);
@@ -16,8 +21,10 @@ fn make_sexpr_tree() {
     const ATOM: Kind = Kind(3);
     const LIST: Kind = Kind(4);
 
+    let mut builder = green::TreeBuilder::new();
+
     #[rustfmt::skip]
-    let tree = green::TreeBuilder::new()
+    let tree = builder
         .start_node(LIST)
             .token(L_PAREN, "(")
             .token(ATOM, "+")
@@ -37,7 +44,83 @@ fn make_sexpr_tree() {
         .finish_node()
         .finish();
 
-    tree.child_at_offset(5.into());
+    // Save this node for test below.
+    // This produces a node with the same identity as above,
+    // because the builder dedupes nodes with an internal cache.
+    #[rustfmt::skip]
+    let inner_mul = builder
+        .start_node(LIST)
+            .token(L_PAREN, "(")
+            .token(ATOM, "*")
+            .token(WS, " ")
+            .token(ATOM, "15")
+            .token(WS, " ")
+            .token(ATOM, "2")
+            .token(R_PAREN, ")")
+        .finish_node()
+        .finish();
+
+    // Some random operations to make sure they work:
+    assert!(ptr::eq(&*tree.child_at_offset(5.into()).unwrap_node(), &*inner_mul));
+    tree.children().for_each(drop);
+
+    if cfg!(miri) {
+        dbg!(tree);
+    } else {
+        insta::assert_debug_snapshot!(tree);
+    }
+}
+
+/// This test creates a tree for the math
+///
+/// ```math
+/// 1 + 2 * 3 + 4
+/// ```
+///
+/// For clarity, this groups as:
+///
+/// ```math
+/// ((1 + (2 * 3)) + 4)
+/// ```
+///
+/// This test shows an example of using the bottom-up `Builder`.
+#[test]
+fn make_math_tree() {
+    const WS: Kind = Kind(0);
+    const OP: Kind = Kind(1);
+    const NUM: Kind = Kind(2);
+    const EXPR: Kind = Kind(3);
+
+    let mut builder = green::Builder::new();
+
+    let ws = builder.token(WS, " ");
+    let n1 = builder.token(NUM, "1");
+    let n2 = builder.token(NUM, "2");
+    let n3 = builder.token(NUM, "3");
+    let n4 = builder.token(NUM, "4");
+    let add = builder.token(OP, "+");
+    let mul = builder.token(OP, "*");
+
+    // Invocations of the builder with the same (id) arguments produces the same (id) results
+    assert!(Arc::ptr_eq(&ws, &builder.token(WS, " ")));
+
+    // builder.node accepts iterator of Arc<Node>, Arc<Token>, or NodeOrToken<Arc<Node>, Arc<Token>>
+    // so if you're mixing nodes and tokens, you need to include the type changing boilerplate.
+    // You'll know if you need the bottom-up builder (LR or such). Use TreeBuilder otherwise.
+    let n = |node: &Arc<green::Node>| NodeOrToken::from(node.clone());
+    let t = |token: &Arc<green::Token>| NodeOrToken::from(token.clone());
+
+    // We use vec![] as a quick and easy ExactSizeIterator.
+    // Particular implementations may use specialized iterators for known child array lengths.
+    // (Please, const-generic angels, give us `[_; N]: IntoIterator` sooner rather than later!)
+    let inner_mul = builder.node(EXPR, vec![n2, ws.clone(), mul, ws.clone(), n3]);
+    let left_add = builder.node(EXPR, vec![t(&n1), t(&ws), t(&add), t(&ws), n(&inner_mul)]);
+    let right_add = builder.node(EXPR, vec![n(&left_add), t(&ws), t(&add), t(&ws), t(&n4)]);
+
+    let tree = right_add;
+
+    // Some random operations to make sure they work:
+    assert!(ptr::eq(&*tree.child_at_offset(5.into()).unwrap_node(), &*left_add));
     tree.children().for_each(drop);
 
     if cfg!(miri) {

--- a/tests/snapshots/smoke__make_math_tree.snap
+++ b/tests/snapshots/smoke__make_math_tree.snap
@@ -1,0 +1,90 @@
+---
+source: tests/smoke.rs
+expression: tree
+---
+Node {
+    children_len: 5,
+    kind: Kind(3),
+    text_len: 13,
+    children: [
+        (offset 0) Node {
+            children_len: 5,
+            kind: Kind(3),
+            text_len: 9,
+            children: [
+                (offset 0) Token {
+                    text_len: 1,
+                    kind: Kind(2),
+                    text: "1",
+                },
+                (offset 1) Token {
+                    text_len: 1,
+                    kind: Kind(0),
+                    text: " ",
+                },
+                (offset 2) Token {
+                    text_len: 1,
+                    kind: Kind(1),
+                    text: "+",
+                },
+                (offset 3) Token {
+                    text_len: 1,
+                    kind: Kind(0),
+                    text: " ",
+                },
+                (offset 4) Node {
+                    children_len: 5,
+                    kind: Kind(3),
+                    text_len: 5,
+                    children: [
+                        (offset 0) Token {
+                            text_len: 1,
+                            kind: Kind(2),
+                            text: "2",
+                        },
+                        (offset 1) Token {
+                            text_len: 1,
+                            kind: Kind(0),
+                            text: " ",
+                        },
+                        (offset 2) Token {
+                            text_len: 1,
+                            kind: Kind(1),
+                            text: "*",
+                        },
+                        (offset 3) Token {
+                            text_len: 1,
+                            kind: Kind(0),
+                            text: " ",
+                        },
+                        (offset 4) Token {
+                            text_len: 1,
+                            kind: Kind(2),
+                            text: "3",
+                        },
+                    ],
+                },
+            ],
+        },
+        (offset 9) Token {
+            text_len: 1,
+            kind: Kind(0),
+            text: " ",
+        },
+        (offset 10) Token {
+            text_len: 1,
+            kind: Kind(1),
+            text: "+",
+        },
+        (offset 11) Token {
+            text_len: 1,
+            kind: Kind(0),
+            text: " ",
+        },
+        (offset 12) Token {
+            text_len: 1,
+            kind: Kind(2),
+            text: "4",
+        },
+    ],
+}

--- a/tests/snapshots/smoke__make_sexpr_tree.snap
+++ b/tests/snapshots/smoke__make_sexpr_tree.snap
@@ -1,0 +1,83 @@
+---
+source: tests/smoke.rs
+expression: tree
+---
+Node {
+    children_len: 7,
+    kind: Kind(4),
+    text_len: 15,
+    children: [
+        (offset 0) Token {
+            text_len: 1,
+            kind: Kind(1),
+            text: "(",
+        },
+        (offset 1) Token {
+            text_len: 1,
+            kind: Kind(3),
+            text: "+",
+        },
+        (offset 2) Token {
+            text_len: 1,
+            kind: Kind(0),
+            text: " ",
+        },
+        (offset 3) Node {
+            children_len: 7,
+            kind: Kind(4),
+            text_len: 8,
+            children: [
+                (offset 0) Token {
+                    text_len: 1,
+                    kind: Kind(1),
+                    text: "(",
+                },
+                (offset 1) Token {
+                    text_len: 1,
+                    kind: Kind(3),
+                    text: "*",
+                },
+                (offset 2) Token {
+                    text_len: 1,
+                    kind: Kind(0),
+                    text: " ",
+                },
+                (offset 3) Token {
+                    text_len: 2,
+                    kind: Kind(3),
+                    text: "15",
+                },
+                (offset 5) Token {
+                    text_len: 1,
+                    kind: Kind(0),
+                    text: " ",
+                },
+                (offset 6) Token {
+                    text_len: 1,
+                    kind: Kind(3),
+                    text: "2",
+                },
+                (offset 7) Token {
+                    text_len: 1,
+                    kind: Kind(2),
+                    text: ")",
+                },
+            ],
+        },
+        (offset 11) Token {
+            text_len: 1,
+            kind: Kind(0),
+            text: " ",
+        },
+        (offset 12) Token {
+            text_len: 2,
+            kind: Kind(3),
+            text: "62",
+        },
+        (offset 14) Token {
+            text_len: 1,
+            kind: Kind(2),
+            text: ")",
+        },
+    ],
+}


### PR DESCRIPTION
Sorbus needs some tests to be run under miri before I'm completely confident in this implementation, but I'm fairly certain it's correct. We don't explicitly take advantage of the fact that the order always flip-flops, and rely on the compiler to notice such to eliminate alignment checks.

_Once we have tests/benchmarks_, we can add parity tracking to `green::node::Children` such that we can unroll internal iteration to size-2 strides that do not have to check parity. `Drop` already does this, it's just more work for `Children` which also does external iteration.

Additionally, since `Element` is now an alignment-sensitive type, more of the construction code is dealing in `NodeOrToken<Arc<Node>, Arc<Token>>` than previously. We can probably move the compression/erasure to `Union2<Arc<Node>, Arc<Token>>` earlier to reduce the amount of data said functions have to move around.

-----

cc @matklad
