### PR TITLE
Fix the leaks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ authors = [
 [dependencies]
 erasable = "1.1" # public
 hashbrown = "0.7"
-ptr-union = "1.2"
+ptr-union = "2.0.0-pre"
 rc-borrow = "1.1" # public
 slice-dst = "1.3" # public
 text-size = "0.99" # public

--- a/src/green/builder.rs
+++ b/src/green/builder.rs
@@ -139,8 +139,8 @@ impl TreeBuilder {
     }
 
     /// The `Builder` used to create and deduplicate nodes.
-    pub fn builder(&self) -> &Builder {
-        &self.cache
+    pub fn builder(&mut self) -> &mut Builder {
+        &mut self.cache
     }
 
     /// Add an element to the current branch.

--- a/src/green/element.rs
+++ b/src/green/element.rs
@@ -24,7 +24,7 @@ use {
         ArcBorrow, NodeOrToken, TextSize,
     },
     erasable::{ErasablePtr, ErasedPtr},
-    ptr_union::{Enum2, Union2, UnionBuilder},
+    ptr_union::{Builder2, Enum2, Union2},
     std::{
         fmt::{self, Debug},
         hash::{self, Hash},
@@ -34,8 +34,7 @@ use {
 };
 
 // SAFETY: align of Node and Token are >= 2
-const ARC_UNION_PROOF: UnionBuilder<Union2<Arc<Node>, Arc<Token>>> =
-    unsafe { UnionBuilder::new2() };
+const ARC_UNION_PROOF: Builder2<Arc<Node>, Arc<Token>> = unsafe { Builder2::new_unchecked() };
 
 /// # Safety
 ///


### PR DESCRIPTION
Well, this is embarrassing.

ptr-union was missing a `Drop` impl, causing dropping a ptr-union union to not drop the wrapped pointers. This is fixed with version 2.0.0 (the fix, sadly, is breaking).

---

bors: r+