### PR TITLE
Fix 32 bit

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -99,8 +99,13 @@ jobs:
         with:
           command: miri
           args: setup
-      - name: Test
+      - name: Test 64 bit target
         uses: actions-rs/cargo@v1
         with:
           command: miri
-          args: test
+          args: test --target x86_64-unknown-linux-gnu
+      - name: Test 32 bit target
+        uses: actions-rs/cargo@v1
+        with:
+          command: miri
+          args: test --target i686-unknown-linux-gnu


### PR DESCRIPTION
Because `usize` is only `u32` big on 32 bit platforms, the resulting element is always fully aligned to an 8 byte boundary.

To support this smoothly, we alias the half-aligned type/implementation to the full-aligned type/implementation when on a 32 bit platform. The optimizer should be able to note that both cases in the union are the same and optimize out the branch between the two cases.

In the name of simplicity, this patch only changes the implementation of the flip-flop element packing. The node children iterator still keeps track of child parity, even though this does nothing on 32 bit platforms.

---

bors: r+