### PR TITLE
Nonrecursive drop for green::Node

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ ptr-union = "2.0.0-pre"
 rc-borrow = "1.1" # public
 slice-dst = "1.3" # public
 text-size = "0.99" # public
+unchecked_unwrap = "1.0"
 
 # Hashbrown is used directly only for access to std's unstable hash_raw_entry.
 # If/when hash_raw_entry is stabilized, this dependency should be removed.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ ptr-union = "2.0.0-pre"
 rc-borrow = "1.1" # public
 slice-dst = "1.3" # public
 text-size = "0.99" # public
-unchecked_unwrap = "1.0"
 
 # Hashbrown is used directly only for access to std's unstable hash_raw_entry.
 # If/when hash_raw_entry is stabilized, this dependency should be removed.

--- a/src/green/element.rs
+++ b/src/green/element.rs
@@ -256,33 +256,6 @@ impl HalfAlignedElement {
     }
 }
 
-impl Drop for FullAlignedElement {
-    #[allow(clippy::deref_addrof)] // tell rustc that it's aligned
-    fn drop(&mut self) {
-        debug_assert!(
-            self as *const _ as usize % 8 == 0,
-            "dropped a half-aligned element as a full-aligned element; this is UB!",
-        );
-        unsafe {
-            <Union2<Arc<Node>, Arc<Token>> as ErasablePtr>::unerase(*&self.repr.ptr);
-        }
-    }
-}
-
-#[cfg(target_pointer_width = "64")]
-impl Drop for HalfAlignedElement {
-    #[allow(clippy::deref_addrof)] // tell rustc that it's aligned
-    fn drop(&mut self) {
-        debug_assert!(
-            self as *const _ as usize % 8 == 4,
-            "dropped a full-aligned element as a half-aligned element; this is UB!",
-        );
-        unsafe {
-            <Union2<Arc<Node>, Arc<Token>> as ErasablePtr>::unerase(*&self.repr.ptr);
-        }
-    }
-}
-
 impl Debug for Element {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "(offset {:?}) ", &self.offset())?;

--- a/src/green/element.rs
+++ b/src/green/element.rs
@@ -196,6 +196,11 @@ impl FullAlignedElement {
         unsafe { *&self.repr.offset }
     }
 
+    #[allow(clippy::deref_addrof)] // tell rustc that it's aligned
+    pub(super) unsafe fn take(&mut self) -> Union2<Arc<Node>, Arc<Token>> {
+        ErasablePtr::unerase(*&self.repr.ptr)
+    }
+
     pub(super) unsafe fn write(
         ptr: *mut Element,
         element: NodeOrToken<Arc<Node>, Arc<Token>>,
@@ -225,6 +230,11 @@ impl HalfAlignedElement {
     #[allow(clippy::deref_addrof)] // tell rustc that it's aligned
     pub(super) fn offset(&self) -> TextSize {
         unsafe { *&self.repr.offset }
+    }
+
+    #[allow(clippy::deref_addrof)] // tell rustc that it's aligned
+    pub(super) unsafe fn take(&mut self) -> Union2<Arc<Node>, Arc<Token>> {
+        ErasablePtr::unerase(*&self.repr.ptr)
     }
 
     pub(super) unsafe fn write(

--- a/src/green/node.rs
+++ b/src/green/node.rs
@@ -10,8 +10,7 @@ use {
     ptr_union::{Enum2, Union2},
     slice_dst::{AllocSliceDst, SliceDst},
     std::{
-        alloc::Layout, hash, iter::FusedIterator, mem, mem::ManuallyDrop, ptr, slice, sync::Arc,
-        u16,
+        alloc::Layout, hash, iter::FusedIterator, mem::ManuallyDrop, ptr, slice, sync::Arc, u16,
     },
     text_size::TextLen,
 };
@@ -50,45 +49,31 @@ impl hash::Hash for Node {
 }
 
 // Element is a union, so we have to make sure to drop them manually here.
-impl Node {
-    fn drop_to(mut self: Arc<Self>, stack: &mut Vec<Union2<Arc<Node>, Arc<Token>>>) {
-        if Arc::get_mut(&mut self).is_some() {
-            unsafe {
-                // UB: https://internals.rust-lang.org/t/_/12229?u=cad97
-                let mut this: Arc<ManuallyDrop<Self>> = mem::transmute(self);
-                let this = &mut *Arc::get_mut(&mut this).unwrap();
-                let mut children = this.children.iter_mut();
-                (|| -> Option<()> {
-                    loop {
-                        stack.push(children.next()?.full_aligned_mut().take());
-                        stack.push(children.next()?.half_aligned_mut().take());
-                    }
-                })();
-            }
-        } else {
-            drop(self);
-        }
-    }
-}
-
 impl Drop for Node {
     fn drop(&mut self) {
         let mut stack = vec![];
 
-        let mut children = self.children.iter_mut();
-        unsafe {
+        unsafe fn take_children(this: &mut Node, stack: &mut Vec<Union2<Arc<Node>, Arc<Token>>>) {
+            let mut children = this.children.iter_mut();
             (|| -> Option<()> {
                 loop {
-                    stack.push(children.next()?.full_aligned_mut().take());
-                    stack.push(children.next()?.half_aligned_mut().take());
+                    stack.push(children.next()?.full_aligned_mut().take()?);
+                    stack.push(children.next()?.half_aligned_mut().take()?);
                 }
             })();
-        }
+        };
 
-        while let Some(element) = stack.pop() {
-            match element.unpack() {
-                Enum2::A(node) => node.drop_to(&mut stack),
-                Enum2::B(token) => drop(token),
+        unsafe {
+            take_children(self, &mut stack);
+            while let Some(element) = stack.pop() {
+                match element.unpack() {
+                    Enum2::A(mut node) => {
+                        if let Some(node) = Arc::get_mut(&mut node) {
+                            take_children(node, &mut stack);
+                        }
+                    }
+                    Enum2::B(token) => drop(token),
+                }
             }
         }
     }

--- a/tests/whoops-linked-list.rs
+++ b/tests/whoops-linked-list.rs
@@ -1,0 +1,18 @@
+use sorbus::{green, Kind};
+
+#[test]
+fn whoops_linked_list() {
+    // miri runs out of stack during drop at this size
+    const RECURSION_FACTOR: usize = 16;
+    const KIND: Kind = Kind(0);
+
+    let mut builder = green::TreeBuilder::new();
+    for _ in 0..RECURSION_FACTOR {
+        builder.start_node(KIND);
+    }
+    builder.token(KIND, " ");
+    for _ in 0..RECURSION_FACTOR {
+        builder.finish_node();
+    }
+    let _tree = builder.finish();
+}


### PR DESCRIPTION
Via taking out the child pointers in a loop.

- af64fd6 was the first attempt, which is UB as written because you cannot transmute `Arc<T>` to `Arc<ManuallyDrop<T>>` in current Rust.
- a45eb2b implements a "C++ nondestructive move" that takes out the children but still drops the node.
- c6fb065 returns to not having to drop the child nodes at all, because it is sound to reinterpret an `Arc`'s payload by using `into_raw`, `from_raw`, and pointer casts.