### PR TITLE
Remove --all-targets from miri invocation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,12 +108,12 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: miri
-          args: test --all-features --all-targets --target x86_64-unknown-linux-gnu
+          args: test --all-features --target x86_64-unknown-linux-gnu
       - name: Test 32 bit target
         uses: actions-rs/cargo@v1
         with:
           command: miri
-          args: test --all-features --all-targets --target i686-unknown-linux-gnu
+          args: test --all-features --target i686-unknown-linux-gnu
 
   coverage:
     name: Coverage (tarpaulin)

--- a/examples/pratt_parser.rs
+++ b/examples/pratt_parser.rs
@@ -254,7 +254,6 @@ fn tests() {
 
 fn main() -> std::io::Result<()> {
     use std::io::BufRead;
-    #[cfg(not(miri))]
     for line in std::io::stdin().lock().lines() {
         let line = line?;
         let s = expr(&line);


### PR DESCRIPTION
as per [this comment](https://github.com/rust-lang/miri/issues/739#issuecomment-626521679) --all-targets violates assumptions within the miri driver. 

---
bors: r+
:robot: