### PR TITLE
Remove children alignment tracking

### DIFF
--- a/src/green/element.rs
+++ b/src/green/element.rs
@@ -323,3 +323,22 @@ impl HalfAlignedElement {
         ptr::write(ptr, element);
     }
 }
+
+impl<'a> From<&'a Element> for NodeOrToken<ArcBorrow<'a, Node>, ArcBorrow<'a, Token>> {
+    fn from(this: &'a Element) -> Self {
+        let this = this.ptr();
+        None.or_else(|| this.with_a(|&node| NodeOrToken::Node(node)))
+            .or_else(|| this.with_b(|&token| NodeOrToken::Token(token)))
+            .unwrap()
+    }
+}
+
+impl<'a> From<&'a Element> for (TextSize, NodeOrToken<ArcBorrow<'a, Node>, ArcBorrow<'a, Token>>) {
+    fn from(this: &'a Element) -> Self {
+        if this.is_full_aligned() {
+            unsafe { this.full_aligned().into() }
+        } else {
+            unsafe { this.half_aligned().into() }
+        }
+    }
+}


### PR DESCRIPTION
and use the alignment of the pointer to determine it.

Alignment checks are still manually unrolled and omitted for internal iteration (`fold`).

See #34 for some more discussion about this touching of optimizer-sensitive code. TL;DR:

```
flat_children  thrpt: -0.10% (p < 0.05, change within noise threshold)
visit_children thrpt: +0.42% (p < 0.05, change within noise threshold)
```

---

closes #34, pretty much
bors: r+

🤖