### PR TITLE
Remove allocation for builder cache hits

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: nightly
           override: true
           components: clippy
       - name: Check
@@ -41,7 +41,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: nightly
           override: true
           components: rustfmt
       - name: Check
@@ -60,7 +60,7 @@ jobs:
         id: toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: nightly
           profile: minimal
           override: true
       - name: Cache

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 //!
 //!   [rowan]: <lib.rs/rowan>
 
+#![feature(vec_drain_as_slice)]
 #![forbid(unconditional_recursion)]
 #![warn(missing_debug_implementations, missing_docs)]
 
@@ -45,4 +46,25 @@ fn test_send_sync() {
     fn assert_send_sync<T: Send + Sync>() {}
     assert_send_sync::<Arc<green::Node>>();
     assert_send_sync::<Arc<green::Token>>();
+}
+
+pub(crate) use as_slice_trait::AsSlice;
+mod as_slice_trait {
+    use std::vec;
+
+    pub trait AsSlice<T> {
+        fn as_slice(&self) -> &[T];
+    }
+
+    impl<T> AsSlice<T> for vec::IntoIter<T> {
+        fn as_slice(&self) -> &[T] {
+            self.as_slice()
+        }
+    }
+
+    impl<T> AsSlice<T> for vec::Drain<'_, T> {
+        fn as_slice(&self) -> &[T] {
+            self.as_slice()
+        }
+    }
 }

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -114,12 +114,15 @@ fn make_math_tree() {
     let n = |node: &Arc<green::Node>| NodeOrToken::from(node.clone());
     let t = |token: &Arc<green::Token>| NodeOrToken::from(token.clone());
 
+    // XXX Inaccurate comments for proof-of-concept direct use of slice views for less alloc XXX
     // We use vec![] as a quick and easy ExactSizeIterator.
     // Particular implementations may use specialized iterators for known child array lengths.
     // (Please, const-generic angels, give us `[_; N]: IntoIterator` sooner rather than later!)
-    let inner_mul = builder.node(EXPR, vec![n2, ws.clone(), mul, ws.clone(), n3]);
-    let left_add = builder.node(EXPR, vec![t(&n1), t(&ws), t(&add), t(&ws), n(&inner_mul)]);
-    let right_add = builder.node(EXPR, vec![n(&left_add), t(&ws), t(&add), t(&ws), t(&n4)]);
+    let inner_mul = builder.node(EXPR, vec![t(&n2), t(&ws), t(&mul), t(&ws), t(&n3)].into_iter());
+    let left_add =
+        builder.node(EXPR, vec![t(&n1), t(&ws), t(&add), t(&ws), n(&inner_mul)].into_iter());
+    let right_add =
+        builder.node(EXPR, vec![n(&left_add), t(&ws), t(&add), t(&ws), t(&n4)].into_iter());
 
     let tree = right_add;
 


### PR DESCRIPTION
Credit to @simonvandel [over at the main rowan repository](https://github.com/rust-analyzer/rowan/pull/59) for pointing out how this is possible.

Draft proof of concept includes many problematic corners that make this not mergeable:

- Nightly-only for [`vec::Drain::as_slice`](https://doc.rust-lang.org/nightly/std/vec/struct.Drain.html#method.as_slice) (https://github.com/rust-lang/rust/issues/58957)
- Includes a bunch of `ptr-union` wrangling in `green/builder.rs` that shouldn't need to be there
  - Should probably use a `fn Union2::as_untagged_ptr` rather than unpacking the union
- `trait AsSlice` is a hack to accept the `as_slice`-having by-value iterators
  - `AsRef<[T]>` is probably the correct bound here
- APIs should go back to taking `IntoIterator` rather than `Iterator` directly
  - The `Into` bound is nice but unnecessary
- Should maintain having an API that doesn't require `as_slice`/`RandomAccessIterator` and performs the old behavior of collecting into a provisional node
- Need to go over deserialization paths to see if any are impacted (or improved) by this technique
- Code is ugly and commits sins on `match` (though not as nice as `match match match`)