### PR TITLE
Add ability to gc builder cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,9 +289,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96282e96bfcd3da0d3aa9938bedf1e50df3269b6db08b4876d2da0bb1a0841cf"
+checksum = "ab9b7860757ce258c89fd48d28b68c41713e597a7b09e793f6c6a6e2ea37c827"
 dependencies = [
  "ahash",
  "autocfg",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "Apache-2.0 / MIT"
 [dependencies]
 ahash = "0.3"
 erasable = "1.2" # public
-hashbrown = "0.7"
+hashbrown = "0.8"
 ptr-union = "2.1"
 rc-borrow = "1.3" # public
 rc-box = { version = "1.1", features = ["slice-dst"] }

--- a/tests/gc.rs
+++ b/tests/gc.rs
@@ -1,0 +1,33 @@
+use sorbus::*;
+
+#[test]
+fn works_properly() {
+    let kind0 = Kind(0);
+    let kind1 = Kind(1);
+    let kind2 = Kind(2);
+    let mut builder = green::TreeBuilder::new();
+
+    #[rustfmt::skip]
+    let inner = builder
+        .start_node(kind1)
+            .token(kind0, "kind")
+        .finish_node()
+    .finish();
+
+    #[rustfmt::skip]
+    let outer = builder
+        .start_node(kind2)
+            .add(inner.clone())
+        .finish_node()
+    .finish();
+
+    assert_eq!(builder.builder().size(), 3);
+
+    drop(outer);
+    builder.builder().gc();
+    assert_eq!(builder.builder().size(), 2);
+
+    drop(inner);
+    builder.builder().gc();
+    assert_eq!(builder.builder().size(), 0);
+}


### PR DESCRIPTION
Draft while blocked on https://github.com/rust-lang/hashbrown/pull/163

Also likely useful along these lines: a preload function that takes an `ArcBorrow<'_, Node>` and preloads the cache with the node and any transitive children.

`drain_filter` is annoying -- what's the polarity of the filter? -- so this definitely needs a test to make sure it's keeping the correct elements.