### PR TITLE
Make sure node dedupe checks all children's id eq

### DIFF
--- a/src/green/builder.rs
+++ b/src/green/builder.rs
@@ -18,8 +18,11 @@ struct ThinEqNode(Arc<Node>);
 impl Eq for ThinEqNode {}
 impl PartialEq for ThinEqNode {
     fn eq(&self, other: &Self) -> bool {
+        // We can skip `len` (the textual length) as it is derived from `children`,
+        // but we do need to make sure that the children array length is equal;
+        // Iterator::zip just truncates the longer iterator.
         self.0.kind() == other.0.kind()
-            // we can skip `len` as it is derived from `children`
+            && self.0.children().len() == other.0.children().len()
             && self.0.children().zip(other.0.children()).all(|pair| match pair {
                 (NodeOrToken::Node(lhs), NodeOrToken::Node(rhs)) => ptr::eq(&*lhs, &*rhs),
                 (NodeOrToken::Token(lhs), NodeOrToken::Token(rhs)) => ptr::eq(&*lhs, &*rhs),


### PR DESCRIPTION
Pointed out by @steffahn on urlo.  Iterator::zip truncates the length of the longer iterator and just uses the length of the shorter iterator. In order to prevent nodes being deduped with nodes that have a strict prefix of the same id children, we have to first check the number of children present separately from the Iterator::zip pair checking.  This is an isidiously hidden bug, as it requires a (partial) hash collision before even revealing itself, as the nodes would have to collide in the hash table before even being checked for equality in this manner. 

---
bors: r+
:robot: