### PR TITLE
[Idea] Thunk tokens

### DIFF
--- a/examples/pratt_parser.rs
+++ b/examples/pratt_parser.rs
@@ -81,7 +81,7 @@ fn to_sexpr(node: &green::Node) -> String {
         f: &'a mut dyn fmt::Write,
     ) -> fmt::Result {
         match el {
-            NodeOrToken::Token(token) => write!(f, "{}", token.text())?,
+            NodeOrToken::Token(token) => write!(f, "{}", token.text().unwrap())?,
             NodeOrToken::Node(node) => {
                 let children_of_interest: Vec<_> =
                     node.children().filter(|el| el.kind() != WS).collect();


### PR DESCRIPTION
Or, in plainer terms, `Token`s that don't store their text.

This is accomplished by defining an invalid string array prefix (`[0xFF]`) to mean the token is a Thunk. When de-thinning a pointer to a Token, if the length of the token is more than 0, we check the first byte of the text. If it's `0xFF`, we know this is a Thunk, so create a fat pointer with trailing array length of 1. If either of those preconditions are false, we have a regular Token, and use the recovered TextSize as the trailing array length.

-----

Needs actual tests for the thunk token before landing. This is a draft PR to share the idea and check this (probably) doesn't break regular tokens.