### PR TITLE
Revert "Remove cumulative offset storage from tree"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -28,10 +39,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "bstr"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31accafdb70df7871592c058eca3985b71104e15ac32f64706022c58867da931"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
+
+[[package]]
 name = "byteorder"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+
+[[package]]
+name = "cast"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9434b9a5aa1450faa3f9cb14ea0e8c53bb5d2b3c1bfd1ab4fc03e9f33fbfb0"
+dependencies = [
+ "rustc_version",
+]
+
+[[package]]
+name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "clap"
+version = "2.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdfa80d47f954d53a35a64987ca1422f495b8d6483c0fe9f7117b36c2a792129"
+dependencies = [
+ "bitflags",
+ "textwrap",
+ "unicode-width",
+]
 
 [[package]]
 name = "console"
@@ -48,6 +103,112 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70daa7ceec6cf143990669a04c7df13391d55fb27bd4079d252fca774ba244d8"
+dependencies = [
+ "atty",
+ "cast",
+ "clap",
+ "criterion-plot",
+ "csv",
+ "itertools",
+ "lazy_static",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_cbor",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022feadec601fba1649cfa83586381a4ad31c6bf3a9ab7d408118b05dd9889d"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "maybe-uninit",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "lazy_static",
+ "maybe-uninit",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "774ba60a54c213d409d5353bda12d49cd68d14e45036a285234c8d6f91f92570"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "maybe-uninit",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "lazy_static",
+]
+
+[[package]]
+name = "csv"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00affe7f6ab566df61b4be3ce8cf16bc2576bca0963ceb0955e45d514bf9a279"
+dependencies = [
+ "bstr",
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "difference"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -58,6 +219,12 @@ name = "dtoa"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
+
+[[package]]
+name = "either"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 
 [[package]]
 name = "encode_unicode"
@@ -76,12 +243,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d36fab90f82edc3c747f9d438e06cf0a491055896f2a279638bb5beed6c40177"
+
+[[package]]
 name = "hashbrown"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab9b7860757ce258c89fd48d28b68c41713e597a7b09e793f6c6a6e2ea37c827"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -100,10 +282,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
+
+[[package]]
+name = "js-sys"
+version = "0.3.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4b9172132a62451e56142bff9afc91c8e4a4500aa5b847da36815b63bfda916"
+dependencies = [
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy_static"
@@ -124,6 +324,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a"
 
 [[package]]
+name = "log"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "maybe-uninit"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
+
+[[package]]
+name = "memchr"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
+
+[[package]]
+name = "memoffset"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c198b026e1bbf08a937e94c6c60f9ec4a2267f5b0d2eec9c1b21b061ce2be55f"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "oorandom"
+version = "11.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a170cebd8021a008ea92e4db85a72f80b35df514ec664b296fdcbb654eac0b2c"
+
+[[package]]
 name = "paste"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -140,6 +395,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d95a7db200b97ef370c8e6de0088252f7e0dfff7d047a28528e47456c0fc98b6"
 dependencies = [
  "proc-macro-hack",
+]
+
+[[package]]
+name = "plotters"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d1685fbe7beba33de0330629da9d955ac75bd54f33d7b79f9a895590124f6bb"
+dependencies = [
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -178,6 +445,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62f02856753d04e03e26929f820d0a0a337ebe71f849801eea335d464b349080"
+dependencies = [
+ "autocfg",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e92e15d89083484e11353891f1af602cc661426deb9564c298b270c726973280"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-queue",
+ "crossbeam-utils",
+ "lazy_static",
+ "num_cpus",
+]
+
+[[package]]
 name = "rc-borrow"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,6 +490,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3780fcf44b193bc4d09f36d2a3c87b251da4a046c87795a0d35f4f927ad8e6"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
+
+[[package]]
 name = "ron"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,10 +525,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -221,12 +555,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
 name = "serde"
 version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde_cbor"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e18acfa2f90e8b735b2836ab8d538de304cbb6729a7360729ea5a895d15a622"
+dependencies = [
+ "half",
+ "serde",
 ]
 
 [[package]]
@@ -287,6 +646,7 @@ name = "sorbus"
 version = "0.1.0"
 dependencies = [
  "ahash",
+ "criterion",
  "erasable",
  "hashbrown",
  "insta",
@@ -340,10 +700,110 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d3dc76004a03cec1c5932bca4cdc2e39aaa798e3f82363dd94f9adf6098c12f"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+
+[[package]]
+name = "walkdir"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a634620115e4a229108b71bde263bb4220c483b3f07f5ba514ee8d15064c4c2"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e53963b583d18a5aa3aaae4b4c1cb535218246131ba22a71f05b518098571df"
+dependencies = [
+ "bumpalo",
+ "lazy_static",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fcfd5ef6eec85623b4c6e844293d4516470d8f19cd72d0d12246017eb9060b8"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9adff9ee0e94b926ca81b57f57f86d5545cdcb1d259e21ec9bdd95b901754c75"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7b90ea6c632dd06fd765d44542e234d5e63d9bb917ecd64d79778a13bd79ae"
+
+[[package]]
+name = "web-sys"
+version = "0.3.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "863539788676619aac1a23e2df3655e96b32b0e05eb72ca34ba045ad573c625d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "winapi"
@@ -360,6 +820,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ ser = ["serde", "text-size/serde"]
 de = ["serde", "serde/derive"]
 
 [dev-dependencies]
+criterion = "0.3"
 insta = { version = "0.16", features = ["ron"] }
 serde_json = "1.0.53"
 serde_test = "1.0.110"
@@ -39,3 +40,7 @@ serde_test = "1.0.110"
 [[test]]
 name = "serde"
 required-features = ["ser", "de"]
+
+[[bench]]
+name = "node_children"
+harness = false

--- a/benches/node_children.rs
+++ b/benches/node_children.rs
@@ -1,0 +1,82 @@
+use {
+    criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput},
+    sorbus::{green, ArcBorrow, Kind, NodeOrToken},
+    std::sync::Arc,
+};
+
+fn black_hole<T>(t: T) {
+    black_box(t);
+}
+
+/// Make a green tree containing some number of `(+ (* 15 2) 62)` nodes.
+fn make_tree(scale: usize) -> Arc<green::Node> {
+    const WS: Kind = Kind(0);
+    const L_PAREN: Kind = Kind(1);
+    const R_PAREN: Kind = Kind(2);
+    const ATOM: Kind = Kind(3);
+    const LIST: Kind = Kind(4);
+
+    let mut builder = green::TreeBuilder::new();
+    #[rustfmt::skip]
+    let tree = builder
+        .start_node(LIST)
+            .token(L_PAREN, "(")
+            .token(ATOM, "+")
+            .token(WS, " ")
+            .start_node(LIST)
+                .token(L_PAREN, "(")
+                .token(ATOM, "*")
+                .token(WS, " ")
+                .token(ATOM, "15")
+                .token(WS, " ")
+                .token(ATOM, "2")
+                .token(R_PAREN, ")")
+            .finish_node()
+            .token(WS, " ")
+            .token(ATOM, "62")
+            .token(R_PAREN, ")")
+        .finish_node()
+        .finish();
+
+    builder.start_node(LIST);
+    for _ in 0..scale {
+        builder.add(tree.clone());
+    }
+    builder.finish_node().finish()
+}
+
+fn flat_children_iterate(c: &mut Criterion) {
+    const SCALE: usize = 256;
+    let mut group = c.benchmark_group("flat_children");
+    for &scale in [SCALE, 2 * SCALE, 4 * SCALE, 8 * SCALE, 16 * SCALE].iter() {
+        group.throughput(Throughput::Elements(scale as u64));
+        let tree = make_tree(scale);
+        group.bench_with_input(BenchmarkId::from_parameter(scale), &tree, |b, tree| {
+            b.iter(|| tree.children().for_each(black_hole));
+        });
+    }
+    group.finish();
+}
+
+fn visit(el: NodeOrToken<ArcBorrow<'_, green::Node>, ArcBorrow<'_, green::Token>>) {
+    match el {
+        NodeOrToken::Node(node) => node.children().for_each(visit),
+        NodeOrToken::Token(token) => black_hole(token),
+    }
+}
+
+fn visit_children_iterate(c: &mut Criterion) {
+    const SCALE: usize = 256;
+    let mut group = c.benchmark_group("visit_children");
+    for &scale in [SCALE, 2 * SCALE, 4 * SCALE, 8 * SCALE, 16 * SCALE].iter() {
+        group.throughput(Throughput::Elements(scale as u64));
+        let tree = make_tree(scale);
+        group.bench_with_input(BenchmarkId::from_parameter(scale), &tree, |b, tree| {
+            b.iter(|| tree.children().for_each(visit));
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, flat_children_iterate, visit_children_iterate);
+criterion_main!(benches);

--- a/src/green/element.rs
+++ b/src/green/element.rs
@@ -1,45 +1,344 @@
-//! Support routines for working with packed element references.
+//! Child element of a green node, being a textual offset from the parent and
+//! either `Arc<green::Node>` or `Arc<green::Token>`.
 //!
-//! We can pack an enumeration of `Arc<Node>` and `Arc<Token>` into a single `usize`;
-//! this is what is done here, along with functions to pack and unpack the pointers.
+//! To achieve optimal packing, the order of the `TextSize` and the `Arc` is
+//! determined by the alignment of the `Element`. A naive implementation would
+//! have `Element` as `(NodeOrToken<Arc<Node>, Arc<Token>>, TextSize)`.
+//!
+//! The first optimization is by using [`Union2`]. This erases the node/token
+//! pointer to be thin (a single `usize` small) and packs the union of both
+//! pointers into a single pointer's space by tagging in the alignment bits.
+//!
+//! The second optimization is noting that `(Ptr, TextSize)` has a `u32` of
+//! padding. By representing `Element` as padding-free `(usize, u32)` or
+//! `(u32, usize)` depending on alignment, we can eliminate this padding
+//! without sacrificing alignment of any member of the `Element` pair.
+//!
+//! On 32-bit platforms, where pointers have the same size as `TextSize`,
+//! this half-alignment trick is not required (and doesn't work). Instead,
+//! we support 32-bit platforms by silently aliasing the half aligned element
+//! to a full aligned element, because it is always fully aligned.
 
 use {
     crate::{
         green::{Node, Token},
-        ArcBorrow, NodeOrToken,
+        ArcBorrow, NodeOrToken, TextSize,
     },
+    erasable::{ErasablePtr, ErasedPtr},
     ptr_union::{Builder2, Enum2, Union2},
-    std::{mem, sync::Arc},
+    std::{
+        fmt::{self, Debug},
+        hash::{self, Hash},
+        ptr,
+        sync::Arc,
+    },
 };
 
 // SAFETY: align of Node and Token are >= 2
 const ARC_UNION_PROOF: Builder2<Arc<Node>, Arc<Token>> = unsafe { Builder2::new_unchecked() };
-
-pub(super) type Element = Union2<Arc<Node>, Arc<Token>>;
-
-pub(super) fn pack_element(el: NodeOrToken<Arc<Node>, Arc<Token>>) -> Element {
+pub(super) type PackedNodeOrToken = Union2<Arc<Node>, Arc<Token>>;
+pub(super) fn pack_node_or_token(el: NodeOrToken<Arc<Node>, Arc<Token>>) -> PackedNodeOrToken {
     match el {
         NodeOrToken::Node(node) => ARC_UNION_PROOF.a(node),
         NodeOrToken::Token(token) => ARC_UNION_PROOF.b(token),
     }
 }
-
-pub(super) fn unpack_element(el: Element) -> NodeOrToken<Arc<Node>, Arc<Token>> {
+pub(super) fn unpack_node_or_token(el: PackedNodeOrToken) -> NodeOrToken<Arc<Node>, Arc<Token>> {
     match el.unpack() {
         Enum2::A(node) => NodeOrToken::Node(node),
         Enum2::B(token) => NodeOrToken::Token(token),
     }
 }
 
-pub(super) fn borrow_element<'a>(
-    el: &'a Element,
-) -> NodeOrToken<ArcBorrow<'a, Node>, ArcBorrow<'a, Token>> {
-    // SAFETY: @CAD97: I wrote these libraries; Arc/ArcBorrow neccesarily erase to the same ptr;
-    //                 Union2 stores the tagged erased ptr; Arc->Borrow is just a ptr erase.
-    let borrow: Union2<ArcBorrow<'a, Node>, ArcBorrow<'a, Token>> =
-        unsafe { mem::transmute_copy(el) };
-    match borrow.unpack() {
-        Enum2::A(node) => NodeOrToken::Node(node),
-        Enum2::B(token) => NodeOrToken::Token(token),
+/// # Safety
+///
+/// - On a 64 bit target:
+///   - If aligned to 8 bytes, must be `.full_aligned`.
+///   - If aligned to 8 bytes + 4, must be `.half_aligned`.
+/// - On a 32 bit target:
+///   - Must always be aligned to 8 bytes, even though this is overaligned.
+///   - Both `.full_aligned` and `.half_aligned` alias the same implementation.
+///
+/// To avoid leaks, the proper member must be `take`n from.
+#[repr(C, align(4))]
+pub(super) union Element {
+    full_aligned: FullAlignedElementRepr,
+    half_aligned: HalfAlignedElementRepr,
+}
+
+// SAFETY: Element is logically a (TextSize, PackedNodeOrToken)
+// ptr-union is a private dependency, so we assert Union2 send/sync separately
+unsafe impl Send for Element {}
+unsafe impl Sync for Element {}
+
+const _: fn() = || {
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<(TextSize, PackedNodeOrToken)>();
+};
+
+/// # Safety
+///
+/// - Must be aligned to 8 bytes (usize, u64)
+/// - This is only Copy because of requirements for `union`;
+///   logically this is a `(TextSize, PackedNodeOrToken)`,
+///   and must be treated as such.
+#[derive(Copy, Clone)] // required for union
+#[repr(C, packed)]
+struct FullAlignedElementRepr {
+    ptr: ErasedPtr,
+    offset: TextSize,
+}
+
+/// # Safety
+///
+/// Must be aligned to 8 bytes (usize, u64).
+#[repr(transparent)]
+pub(super) struct FullAlignedElement {
+    repr: FullAlignedElementRepr,
+}
+
+/// # Safety
+///
+/// - Must be aligned to 8 bytes + 4 (usize, u64 + 1/2).
+///   (That is, aligned to 4 but not 8.)
+/// - This is only Copy because of requirements for `union`;
+///   logically this is a `(TextSize, PackedNodeOrToken)`,
+///   and must be treated as such.
+#[derive(Copy, Clone)] // required for union
+#[repr(C, packed)]
+#[cfg(target_pointer_width = "64")]
+struct HalfAlignedElementRepr {
+    offset: TextSize,
+    ptr: ErasedPtr,
+}
+
+#[cfg(target_pointer_width = "32")]
+type HalfAlignedElementRepr = FullAlignedElementRepr;
+
+/// # Safety
+///
+/// Must be aligned to 8 bytes + 4 (usize + 1/2).
+/// (That is, aligned to 4 but not 8.)
+#[repr(transparent)]
+#[cfg(target_pointer_width = "64")]
+pub(super) struct HalfAlignedElement {
+    repr: HalfAlignedElementRepr,
+}
+
+#[cfg(target_pointer_width = "32")]
+pub(super) type HalfAlignedElement = FullAlignedElement;
+
+impl Element {
+    #[cfg(target_pointer_width = "64")]
+    pub(super) fn is_full_aligned(&self) -> bool {
+        self as *const Self as usize % 8 == 0
+    }
+
+    #[cfg(target_pointer_width = "32")]
+    pub(super) fn is_full_aligned(&self) -> bool {
+        true
+    }
+
+    pub(super) unsafe fn full_aligned(&self) -> &FullAlignedElement {
+        debug_assert!(
+            self.is_full_aligned(),
+            "called Element::full_aligned on half-aligned element; this is UB!",
+        );
+        &*(&self.full_aligned as *const FullAlignedElementRepr as *const FullAlignedElement)
+    }
+
+    pub(super) unsafe fn full_aligned_mut(&mut self) -> &mut FullAlignedElement {
+        debug_assert!(
+            self.is_full_aligned(),
+            "called Element::full_aligned on half-aligned element; this is UB!",
+        );
+        &mut *(&mut self.full_aligned as *mut FullAlignedElementRepr as *mut FullAlignedElement)
+    }
+
+    #[cfg(target_pointer_width = "64")]
+    pub(super) fn is_half_aligned(&self) -> bool {
+        self as *const Self as usize % 8 == 4
+    }
+
+    #[cfg(target_pointer_width = "32")]
+    pub(super) fn is_half_aligned(&self) -> bool {
+        self.is_full_aligned()
+    }
+
+    pub(super) unsafe fn half_aligned(&self) -> &HalfAlignedElement {
+        debug_assert!(
+            self.is_half_aligned(),
+            "called Element::half_aligned on full-aligned element; this is UB!",
+        );
+        &*(&self.half_aligned as *const HalfAlignedElementRepr as *const HalfAlignedElement)
+    }
+
+    pub(super) unsafe fn half_aligned_mut(&mut self) -> &mut HalfAlignedElement {
+        debug_assert!(
+            self.is_half_aligned(),
+            "called Element::half_aligned on full-aligned element; this is UB!",
+        );
+        &mut *(&mut self.half_aligned as *mut HalfAlignedElementRepr as *mut HalfAlignedElement)
+    }
+
+    pub(super) fn ptr(&self) -> Union2<ArcBorrow<'_, Node>, ArcBorrow<'_, Token>> {
+        if self.is_full_aligned() {
+            unsafe { self.full_aligned().ptr() }
+        } else {
+            unsafe { self.half_aligned().ptr() }
+        }
+    }
+
+    pub(super) fn offset(&self) -> TextSize {
+        if self.is_full_aligned() {
+            unsafe { self.full_aligned().offset() }
+        } else {
+            unsafe { self.half_aligned().offset() }
+        }
+    }
+}
+
+impl Debug for Element {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "(offset {:?}) ", &self.offset())?;
+        match self.ptr().unpack() {
+            Enum2::A(node) => Debug::fmt(&node, f),
+            Enum2::B(token) => Debug::fmt(&token, f),
+        }
+    }
+}
+
+impl Eq for Element {}
+impl PartialEq for Element {
+    fn eq(&self, other: &Self) -> bool {
+        unsafe {
+            match (self.is_full_aligned(), other.is_full_aligned()) {
+                (true, true) => self.full_aligned() == other.full_aligned(),
+                (true, false) => self.full_aligned() == other.half_aligned(),
+                (false, true) => self.half_aligned() == other.half_aligned(),
+                (false, false) => self.half_aligned() == other.half_aligned(),
+            }
+        }
+    }
+}
+
+impl Hash for Element {
+    fn hash<H: hash::Hasher>(&self, state: &mut H) {
+        if self.is_full_aligned() {
+            unsafe { self.full_aligned().hash(state) }
+        } else {
+            unsafe { self.half_aligned().hash(state) }
+        }
+    }
+}
+
+macro_rules! impl_element {
+    ($Element:ident) => {
+        impl $Element {
+            #[allow(clippy::deref_addrof)] // tell rustc that it's aligned
+            pub(super) fn ptr(&self) -> Union2<ArcBorrow<'_, Node>, ArcBorrow<'_, Token>> {
+                unsafe { ErasablePtr::unerase(*&self.repr.ptr) }
+            }
+
+            #[allow(clippy::deref_addrof)] // tell rustc that it's aligned
+            pub(super) fn offset(&self) -> TextSize {
+                unsafe { *&self.repr.offset }
+            }
+
+            #[allow(clippy::deref_addrof)] // tell rustc that it's aligned
+            pub(super) unsafe fn take(&mut self) -> PackedNodeOrToken {
+                ErasablePtr::unerase(*&self.repr.ptr)
+            }
+        }
+
+        impl Eq for $Element {}
+        impl PartialEq<FullAlignedElement> for $Element {
+            fn eq(&self, other: &FullAlignedElement) -> bool {
+                self.ptr() == other.ptr() && self.offset() == other.offset()
+            }
+        }
+
+        #[cfg(target_pointer_width = "64")]
+        impl PartialEq<HalfAlignedElement> for $Element {
+            fn eq(&self, other: &HalfAlignedElement) -> bool {
+                self.ptr() == other.ptr() && self.offset() == other.offset()
+            }
+        }
+
+        impl Hash for $Element {
+            fn hash<H: hash::Hasher>(&self, state: &mut H) {
+                self.ptr().hash(state);
+                self.offset().hash(state);
+            }
+        }
+
+        impl<'a> From<&'a $Element> for NodeOrToken<ArcBorrow<'a, Node>, ArcBorrow<'a, Token>> {
+            fn from(this: &'a $Element) -> Self {
+                let this = this.ptr();
+                None.or_else(|| this.with_a(|&node| NodeOrToken::Node(node)))
+                    .or_else(|| this.with_b(|&token| NodeOrToken::Token(token)))
+                    .unwrap()
+            }
+        }
+
+        impl<'a> From<&'a $Element>
+            for (TextSize, NodeOrToken<ArcBorrow<'a, Node>, ArcBorrow<'a, Token>>)
+        {
+            fn from(this: &'a $Element) -> Self {
+                (this.offset(), this.into())
+            }
+        }
+    };
+}
+
+impl_element!(FullAlignedElement);
+#[cfg(target_pointer_width = "64")]
+impl_element!(HalfAlignedElement);
+
+impl FullAlignedElement {
+    pub(super) unsafe fn write(ptr: *mut Element, element: PackedNodeOrToken, offset: TextSize) {
+        debug_assert!(
+            ptr as usize % 8 == 0,
+            "attempted to write full-aligned element to half-aligned place; this is UB!",
+        );
+        let element = ErasablePtr::erase(element);
+        let ptr = ptr.cast();
+        ptr::write(ptr, element);
+        let ptr = ptr.add(1).cast();
+        ptr::write(ptr, offset);
+    }
+}
+
+#[cfg(target_pointer_width = "64")]
+impl HalfAlignedElement {
+    pub(super) unsafe fn write(ptr: *mut Element, element: PackedNodeOrToken, offset: TextSize) {
+        debug_assert!(
+            ptr as usize % 8 == 4,
+            "attempted to write half-aligned element to full-aligned place; this is UB!",
+        );
+        let element = ErasablePtr::erase(element);
+        let ptr = ptr.cast();
+        ptr::write(ptr, offset);
+        let ptr = ptr.add(1).cast();
+        ptr::write(ptr, element);
+    }
+}
+
+impl<'a> From<&'a Element> for NodeOrToken<ArcBorrow<'a, Node>, ArcBorrow<'a, Token>> {
+    fn from(this: &'a Element) -> Self {
+        let this = this.ptr();
+        None.or_else(|| this.with_a(|&node| NodeOrToken::Node(node)))
+            .or_else(|| this.with_b(|&token| NodeOrToken::Token(token)))
+            .unwrap()
+    }
+}
+
+impl<'a> From<&'a Element> for (TextSize, NodeOrToken<ArcBorrow<'a, Node>, ArcBorrow<'a, Token>>) {
+    fn from(this: &'a Element) -> Self {
+        if this.is_full_aligned() {
+            unsafe { this.full_aligned().into() }
+        } else {
+            unsafe { this.half_aligned().into() }
+        }
     }
 }

--- a/src/green/mod.rs
+++ b/src/green/mod.rs
@@ -10,7 +10,10 @@ mod tree_builder;
 #[cfg(feature = "serde")]
 mod serde;
 
-pub(self) use self::element::{borrow_element, pack_element, unpack_element, Element};
+pub(self) use self::element::{
+    pack_node_or_token, unpack_node_or_token, Element, FullAlignedElement, HalfAlignedElement,
+    PackedNodeOrToken,
+};
 #[doc(inline)]
 pub use self::{
     builder::Builder,

--- a/src/green/tree_builder.rs
+++ b/src/green/tree_builder.rs
@@ -1,6 +1,8 @@
 use {
     crate::{
-        green::{pack_element, unpack_element, Builder, Element, Node, Token},
+        green::{
+            pack_node_or_token, unpack_node_or_token, Builder, Node, PackedNodeOrToken, Token,
+        },
         Kind, NodeOrToken,
     },
     std::{hash::Hash, sync::Arc},
@@ -15,7 +17,7 @@ pub struct Checkpoint(usize);
 pub struct TreeBuilder {
     cache: Builder,
     stack: Vec<(Kind, usize)>,
-    children: Vec<Element>,
+    children: Vec<PackedNodeOrToken>,
 }
 
 impl TreeBuilder {
@@ -36,7 +38,7 @@ impl TreeBuilder {
 
     /// Add an element to the current branch.
     pub fn add(&mut self, element: impl Into<NodeOrToken<Arc<Node>, Arc<Token>>>) -> &mut Self {
-        self.children.push(pack_element(element.into()));
+        self.children.push(pack_node_or_token(element.into()));
         self
     }
 
@@ -199,7 +201,7 @@ impl TreeBuilder {
     pub fn finish(&mut self) -> Arc<Node> {
         assert!(self.stack.is_empty());
         assert_eq!(self.children.len(), 1);
-        unpack_element(self.children.pop().unwrap()).into_node().unwrap()
+        unpack_node_or_token(self.children.pop().unwrap()).into_node().unwrap()
     }
 
     /// Destroy this tree builder and recycle its build cache.

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -61,7 +61,9 @@ fn make_sexpr_tree() {
         .finish();
 
     // Some random operations to make sure they work:
-    let (offset, element) = tree.children_with_offsets().nth(3).unwrap();
+    let index = tree.index_of_offset(5.into());
+    let (offset, element) = tree.children().with_offsets().get(index).unwrap();
+    assert_eq!(index, 3);
     assert_eq!(offset, 3.into());
     assert!(ptr::eq(&*element.unwrap_node(), &*inner_mul));
     tree.children().for_each(drop);
@@ -122,6 +124,11 @@ fn make_math_tree() {
     let tree = right_add;
 
     // Some random operations to make sure they work:
+    let index = tree.index_of_offset(5.into());
+    let (offset, element) = tree.children().with_offsets().get(index).unwrap();
+    assert_eq!(index, 0);
+    assert_eq!(offset, 0.into());
+    assert!(ptr::eq(&*element.unwrap_node(), &*left_add));
     tree.children().for_each(drop);
 
     if cfg!(miri) {

--- a/tests/snapshots/smoke__make_math_tree.snap
+++ b/tests/snapshots/smoke__make_math_tree.snap
@@ -3,58 +3,61 @@ source: tests/smoke.rs
 expression: tree
 ---
 Node {
+    children_len: 5,
     kind: Kind(3),
     text_len: 13,
     children: [
-        Node {
+        (offset 0) Node {
+            children_len: 5,
             kind: Kind(3),
             text_len: 9,
             children: [
-                Token {
+                (offset 0) Token {
                     text_len: 1,
                     kind: Kind(2),
                     text: "1",
                 },
-                Token {
+                (offset 1) Token {
                     text_len: 1,
                     kind: Kind(0),
                     text: " ",
                 },
-                Token {
+                (offset 2) Token {
                     text_len: 1,
                     kind: Kind(1),
                     text: "+",
                 },
-                Token {
+                (offset 3) Token {
                     text_len: 1,
                     kind: Kind(0),
                     text: " ",
                 },
-                Node {
+                (offset 4) Node {
+                    children_len: 5,
                     kind: Kind(3),
                     text_len: 5,
                     children: [
-                        Token {
+                        (offset 0) Token {
                             text_len: 1,
                             kind: Kind(2),
                             text: "2",
                         },
-                        Token {
+                        (offset 1) Token {
                             text_len: 1,
                             kind: Kind(0),
                             text: " ",
                         },
-                        Token {
+                        (offset 2) Token {
                             text_len: 1,
                             kind: Kind(1),
                             text: "*",
                         },
-                        Token {
+                        (offset 3) Token {
                             text_len: 1,
                             kind: Kind(0),
                             text: " ",
                         },
-                        Token {
+                        (offset 4) Token {
                             text_len: 1,
                             kind: Kind(2),
                             text: "3",
@@ -63,22 +66,22 @@ Node {
                 },
             ],
         },
-        Token {
+        (offset 9) Token {
             text_len: 1,
             kind: Kind(0),
             text: " ",
         },
-        Token {
+        (offset 10) Token {
             text_len: 1,
             kind: Kind(1),
             text: "+",
         },
-        Token {
+        (offset 11) Token {
             text_len: 1,
             kind: Kind(0),
             text: " ",
         },
-        Token {
+        (offset 12) Token {
             text_len: 1,
             kind: Kind(2),
             text: "4",

--- a/tests/snapshots/smoke__make_sexpr_tree.snap
+++ b/tests/snapshots/smoke__make_sexpr_tree.snap
@@ -3,76 +3,78 @@ source: tests/smoke.rs
 expression: tree
 ---
 Node {
+    children_len: 7,
     kind: Kind(4),
     text_len: 15,
     children: [
-        Token {
+        (offset 0) Token {
             text_len: 1,
             kind: Kind(1),
             text: "(",
         },
-        Token {
+        (offset 1) Token {
             text_len: 1,
             kind: Kind(3),
             text: "+",
         },
-        Token {
+        (offset 2) Token {
             text_len: 1,
             kind: Kind(0),
             text: " ",
         },
-        Node {
+        (offset 3) Node {
+            children_len: 7,
             kind: Kind(4),
             text_len: 8,
             children: [
-                Token {
+                (offset 0) Token {
                     text_len: 1,
                     kind: Kind(1),
                     text: "(",
                 },
-                Token {
+                (offset 1) Token {
                     text_len: 1,
                     kind: Kind(3),
                     text: "*",
                 },
-                Token {
+                (offset 2) Token {
                     text_len: 1,
                     kind: Kind(0),
                     text: " ",
                 },
-                Token {
+                (offset 3) Token {
                     text_len: 2,
                     kind: Kind(3),
                     text: "15",
                 },
-                Token {
+                (offset 5) Token {
                     text_len: 1,
                     kind: Kind(0),
                     text: " ",
                 },
-                Token {
+                (offset 6) Token {
                     text_len: 1,
                     kind: Kind(3),
                     text: "2",
                 },
-                Token {
+                (offset 7) Token {
                     text_len: 1,
                     kind: Kind(2),
                     text: ")",
                 },
             ],
         },
-        Token {
+        (offset 11) Token {
             text_len: 1,
             kind: Kind(0),
             text: " ",
         },
-        Token {
+        (offset 12) Token {
             text_len: 2,
             kind: Kind(3),
             text: "62",
         },
-        Token {
+        (offset 14) Token {
             text_len: 1,
             kind: Kind(2),
             text: ")",


### PR DESCRIPTION
This reverts PR #67.

Unfortunately, I moved a bit quick here; the cumulative offsets are still necessary to get ***O*(*d*)** `SyntaxPtr` resolution in the red tree. The reason being that the red tree still needs the cumulative offsets; if we don't provide them in ***O*(1)** time, then `SyntaxPtr` resolution has to go through ***O*(*w*)** nodes every depth step to get the cumulative offset, in basically the exact same access pattern that already exists.