### PR TITLE
Update to hashbrown 0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,12 +250,9 @@ checksum = "d36fab90f82edc3c747f9d438e06cf0a491055896f2a279638bb5beed6c40177"
 
 [[package]]
 name = "hashbrown"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab9b7860757ce258c89fd48d28b68c41713e597a7b09e793f6c6a6e2ea37c827"
-dependencies = [
- "autocfg",
-]
+checksum = "00d63df3d41950fb462ed38308eea019113ad1508da725bbedcd0fa5a85ef5f7"
 
 [[package]]
 name = "hermit-abi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "Apache-2.0 / MIT"
 [dependencies]
 ahash = { version = "0.3", default-features = false }
 erasable = "1.2" # public
-hashbrown = { version = "0.8", default-features = false }
+hashbrown = { version = "0.9", default-features = false }
 ptr-union = "2.1"
 rc-borrow = "1.3" # public
 rc-box = { version = "1.1", features = ["slice-dst"] }

--- a/src/green/builder.rs
+++ b/src/green/builder.rs
@@ -216,9 +216,9 @@ impl Builder {
 impl Builder {
     fn collect_root_nodes(&mut self) -> Vec<Arc<Node>> {
         // NB: `drain_filter` is `retain` but with an iterator of the removed elements.
-        // i.e.: elements where the predicate is FALSE are removed and iterated over.
+        // i.e.: elements where the predicate is TRUE are removed and iterated over.
         self.nodes
-            .drain_filter(|node, ()| Arc::strong_count(node) > 1)
+            .drain_filter(|node, ()| Arc::strong_count(node) <= 1)
             .map(|(node, _)| node)
             .collect()
     }

--- a/src/green/builder.rs
+++ b/src/green/builder.rs
@@ -215,7 +215,7 @@ impl Builder {
 
 impl Builder {
     fn collect_root_nodes(&mut self) -> Vec<Arc<Node>> {
-        // NB: `drain_filter` is `retain` but with an iterator of the removed elements.
+        // NB: `drain_filter` is `iter().filter` but also removing the elements chosen.
         // i.e.: elements where the predicate is TRUE are removed and iterated over.
         self.nodes
             .drain_filter(|node, ()| Arc::strong_count(node) <= 1)


### PR DESCRIPTION
The behavior of `drain_filter` has changed in this release:

https://github.com/rust-lang/hashbrown/issues/186